### PR TITLE
[FEAT/#22] 생일 정보 삭제하기+네비게이션 이것저것

### DIFF
--- a/DoBday/DoBday/View/CalendarView.swift
+++ b/DoBday/DoBday/View/CalendarView.swift
@@ -6,10 +6,44 @@
 //
 
 import SwiftUI
+import SwiftData
 
 struct CalendarView: View {
+    @Environment(\.modelContext) var context
+    @Query var bdays: [Bday]
+
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        NavigationView {
+            VStack {
+                NavigationLink("+", destination: CreateBdayView())
+                
+                List{
+                    ForEach(bdays) { bday in
+                        ZStack {
+                            RoundedRectangle(cornerRadius: 20)
+                                .frame(width: 358, height: 104)
+                                .foregroundColor(.gray)
+
+                            HStack {
+                                Circle()
+                                    .frame(width: 72)
+
+                                VStack {
+                                    Text("\(bday.name)의 생일")
+                                    Text(bday.notiFrequency)
+                                }
+                                Spacer()
+                            }
+                        }
+                    }.onDelete { indexSet in
+                        indexSet.forEach({index in
+                            context.delete(bdays[index])
+                        })
+                    }
+                }
+            }
+            .padding()
+        }.navigationTitle("다가오는 생일 리스트")
     }
 }
 

--- a/DoBday/DoBday/View/UpComingBdayView.swift
+++ b/DoBday/DoBday/View/UpComingBdayView.swift
@@ -11,17 +11,19 @@ import SwiftData
 struct UpComingBdayView: View {
     @Environment(\.modelContext) var context
     @Query var bdays: [Bday]
+    
     var body: some View {
         NavigationView {
             VStack {
                 NavigationLink("+", destination: CreateBdayView())
 
-
+                NavigationLink("캘린더 뷰", destination: CalendarView())
 
                 List(bdays) {bday in
                     Text(bday.name)
                     Text("\(String(describing: bday.dateOfBday))")
                 }
+                
             }
             .padding()
         }.navigationTitle("다가오는 생일 리스트")


### PR DESCRIPTION
## #️⃣ 관련 이슈 
- Resolved: #22 

<br/>

## 🌱 구현/변경 사항
- 생일 정보를 스와이프하여 삭제 할 수 있는 코드를 작성하였습니다.(modelContext활용)
- 네비게이션 경로를 정리하였습니다. 

<br/>

## 📷 스크린샷 
|기능|스크린샷|
|:--:|:--:|
|삭제 가능 한 캘린더 뷰-스와이프 형식|<img width="393" alt="스크린샷 2024-10-18 오후 12 29 30" src="https://github.com/user-attachments/assets/43997e79-504e-46f0-a1d4-6114e839f3a7">|

<br/>

## 📚 레퍼런스(선택사항)
https://www.youtube.com/watch?v=2YpNPUhGo44

<br/>

## 📝 etc.(기타 사항 메모)
지금부터는 영의 조언대로 뷰로 나누어 작업할 예정. 수정과 추가 뷰를 합쳐서 쓸 예정. 아직 어떻게 써야할지 잘 모르겠어요..