### PR TITLE
[PR/#28] notiFrequency 데이터 타입 수정(String -> [String]) 및 목업 데이터 수정

### DIFF
--- a/DoBday/DoBday/Model/Bday.swift
+++ b/DoBday/DoBday/Model/Bday.swift
@@ -15,16 +15,16 @@ final class Bday: Identifiable {
     var profileImage: String?
     var dateOfBday: Date?
     var isLunar: Bool
-    var notiFrequency: String
+    var notiFrequency: [String]
     var relationshipTag: String
 
-    init(id: UUID, name: String, profileImage: String? = nil, dateOfBday: Date? = nil, isLunar: Bool, notiFrequency: String, relationshipTag: String) {
+    init(id: UUID, name: String, profileImage: String? = nil, dateOfBday: Date? = nil, isLunar: Bool, notiFrequency: [String], relationshipTag: String) {
         self.id = id
         self.name = name
         self.profileImage = profileImage
         self.dateOfBday = dateOfBday
         self.isLunar = isLunar
-        self.notiFrequency = notiFrequency
+        self.notiFrequency = [ ]
         self.relationshipTag = relationshipTag
     }
 }

--- a/DoBday/DoBday/Model/MockupData.swift
+++ b/DoBday/DoBday/Model/MockupData.swift
@@ -9,8 +9,8 @@ import Foundation
 import SwiftUI
 
 let mockBdayData: [Bday] = [
-    Bday(id: UUID(), name: "소이", profileImage: "soy", dateOfBday: Date(), isLunar: false, notiFrequency: "Weekly"),
-    Bday(id: UUID(), name: "씨네필", profileImage: "cinephil", dateOfBday: Calendar.current.date(byAdding: .day, value: 7, to: Date()), isLunar: false, notiFrequency: "Daily"),
-    Bday(id: UUID(), name: "피카", profileImage: "pika", dateOfBday: Calendar.current.date(byAdding: .month, value: 1, to: Date()), isLunar: true, notiFrequency: "Monthly"),
-    Bday(id: UUID(), name: "레디", profileImage: "ready", dateOfBday: Calendar.current.date(byAdding: .month, value: -3, to: Date()), isLunar: false, notiFrequency: "Weekly")
+    Bday(id: UUID(), name: "소이", profileImage: "soy", dateOfBday: Date(), isLunar: false, notiFrequency: ["당일", "1일 전"], relationshipTag: "#비지니스"),
+    Bday(id: UUID(), name: "씨네필", profileImage: "cinephil", dateOfBday: Calendar.current.date(byAdding: .day, value: 7, to: Date()), isLunar: false, notiFrequency: ["3일 전"], relationshipTag: "#지인"),
+    Bday(id: UUID(), name: "피카", profileImage: "pika", dateOfBday: Calendar.current.date(byAdding: .month, value: 1, to: Date()), isLunar: true, notiFrequency: ["1일 전", "7일 전"], relationshipTag: "#친구"),
+    Bday(id: UUID(), name: "레디", profileImage: "ready", dateOfBday: Calendar.current.date(byAdding: .month, value: -3, to: Date()), isLunar: false, notiFrequency: ["당일"], relationshipTag: "#가족")
 ]

--- a/DoBday/DoBday/View/CalendarView.swift
+++ b/DoBday/DoBday/View/CalendarView.swift
@@ -32,7 +32,7 @@ struct CalendarView: View {
 
                                 VStack {
                                     Text("\(bday.name)의 생일")
-                                    Text(bday.notiFrequency)
+//                                    Text(bday.notiFrequency)
                                 }
                                 Spacer()
                             }

--- a/DoBday/DoBday/View/CreateBdayView.swift
+++ b/DoBday/DoBday/View/CreateBdayView.swift
@@ -30,7 +30,7 @@ struct CreateBdayView: View {
             VStack {
                 //추가 버튼
                 Button {
-                    let newBday = Bday(id: UUID(), name: name, profileImage: profileImage, dateOfBday: dateOfBday, isLunar: isLunar, notiFrequency: notiFrequency, relationshipTag: relationshipTag)
+                    let newBday = Bday(id: UUID(), name: name, profileImage: profileImage, dateOfBday: dateOfBday, isLunar: isLunar, notiFrequency: [notiFrequency], relationshipTag: relationshipTag)
                     context.insert(newBday)
                 } label: {
                     Text("추가")


### PR DESCRIPTION
## #️⃣ 관련 이슈 
- Resolved: #28 

<br/>

## 🌱 구현/변경 사항
- notiFrequency의 데이터 타입을 수정했습니다. (String → [String])
- 데이터 모델에 맞게 목업 데이터를 수정했습니다. 

<br/>

## 📷 스크린샷 
|기능|스크린샷|
|:--:|:--:|
|기능 설명|이미지 주소|

<br/>

## 📚 레퍼런스(선택사항)

<br/>

## 📝 etc.(기타 사항 메모)
- CalendarView의 VStack 부분이 오류가 나서 일단 주석 처리 했습니다.