### PR TITLE
[PR/#50] 오타 수정, 폰트 이름에 bday_ 추가

### DIFF
--- a/DoBday/DoBday/Helper/Helper+Fonts.swift
+++ b/DoBday/DoBday/Helper/Helper+Fonts.swift
@@ -23,46 +23,46 @@ enum Pretendard: String {
 
 extension Font {
     // MARK: - Large Title
-    static let ltEmphasized = Font.custom("Pretendard-Bold", size: 48)
-    static let ltRegular = Font.custom("Pretendard-Regular", size: 48)
+    static let bday_ltEmphasized = Font.custom("Pretendard-Bold", size: 48)
+    static let bday_ltRegular = Font.custom("Pretendard-Regular", size: 48)
     
     // MARK: - Title1
-    static let t1Emphasized = Font.custom("Pretendard-Bold", size: 36)
-    static let t1Regular = Font.custom("Pretendard-Regular", size: 36)
+    static let bday_t1Emphasized = Font.custom("Pretendard-Bold", size: 36)
+    static let bday_t1Regular = Font.custom("Pretendard-Regular", size: 36)
 
     // MARK: - Title2
-    static let t2Emphasized = Font.custom("Pretendard-Bold", size: 22)
-    static let t2Regular = Font.custom("Pretendard-Regular", size: 22)
+    static let bday_t2Emphasized = Font.custom("Pretendard-Bold", size: 22)
+    static let bday_t2Regular = Font.custom("Pretendard-Regular", size: 22)
 
     // MARK: - Title3
-    static let t3Emphasized = Font.custom("Pretendard-Bold", size: 18)
-    static let t3Regular = Font.custom("Pretendard-Regular", size: 18)
+    static let bday_t3Emphasized = Font.custom("Pretendard-Bold", size: 18)
+    static let bday_t3Regular = Font.custom("Pretendard-Regular", size: 18)
     
     // MARK: - Headline
-    static let headEmphasized = Font.custom("Pretendard-Bold", size: 16)
+    static let bday_headEmphasized = Font.custom("Pretendard-Bold", size: 16)
     // MARK: - Body
-    static let bodyEmphasized = Font.custom("Pretendard-SemiBold", size: 16)
-    static let bodyRegular = Font.custom("Pretendard-Regular", size: 16)
+    static let bday_bodyEmphasized = Font.custom("Pretendard-SemiBold", size: 16)
+    static let bday_bodyRegular = Font.custom("Pretendard-Regular", size: 16)
     
     // MARK: - Callout
-    static let  callEmphasized = Font.custom("Pretendard-Bold", size: 14)
-    static let  collRegular = Font.custom("Pretendard-Regular", size: 14)
+    static let  bday_callEmphasized = Font.custom("Pretendard-Bold", size: 14)
+    static let  bday_callRegular = Font.custom("Pretendard-Regular", size: 14)
     
     // MARK: - Sub Headline
-    static let subEmphasized = Font.custom("Pretendard-Bold", size: 13)
-    static let subRegular = Font.custom("Pretendard-Regular", size: 13)
+    static let bday_subEmphasized = Font.custom("Pretendard-Bold", size: 13)
+    static let bday_subRegular = Font.custom("Pretendard-Regular", size: 13)
     
     // MARK: - Foot Note
-    static let footEmphasized = Font.custom("Pretendard-Bold", size: 12)
-    static let footRegular = Font.custom("Pretendard-Regular", size: 12)
+    static let bday_footEmphasized = Font.custom("Pretendard-Bold", size: 12)
+    static let bday_footRegular = Font.custom("Pretendard-Regular", size: 12)
     
     // MARK: - Caption1
-    static let c1Emphasized = Font.custom("Pretendard-Bold", size: 11)
-    static let c1Regular = Font.custom("Pretendard-Regular", size: 11)
+    static let bday_c1Emphasized = Font.custom("Pretendard-Bold", size: 11)
+    static let bday_c1Regular = Font.custom("Pretendard-Regular", size: 11)
     
     // MARK: - Caption2
-    static let c2Emphasized = Font.custom("Pretendard-Bold", size: 10)
-    static let c2Regular = Font.custom("Pretendard-Regular", size: 10)
+    static let bday_c2Emphasized = Font.custom("Pretendard-Bold", size: 10)
+    static let bday_c2Regular = Font.custom("Pretendard-Regular", size: 10)
     
     // MARK: - DateFormat Title
     /// UpcomingView에 사용할 때 lineSpacing(25) 적용하고 사용하면 똑같아짐


### PR DESCRIPTION
## #️⃣ 관련 이슈 
- Resolved: #50 

<br/>

## 🌱 구현/변경 사항
- 오타 수정함

<br/>

## 📷 스크린샷 
|기능|스크린샷|
|:--:|:--:|
|기능은 같아요|<img width="681" alt="image" src="https://github.com/user-attachments/assets/f4703285-87bd-408e-ba33-71f1d562302d">|

<br/>

## 📚 레퍼런스(선택사항)

<br/>

## 📝 etc.(기타 사항 메모)
bday_를 이름에 추가했어요 폰트 찾기가 더 쉬워졌어요
